### PR TITLE
To create a wheel python package

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,6 +2,7 @@ cmake_minimum_required( VERSION 2.8 )
 
 project( pyreclab )
 
+
 set( MAJOR_VERSION "0" )
 set( MINOR_VERSION "1" )
 set( RELEASE_VERSION "7" )
@@ -73,11 +74,12 @@ if( PYTHON )
    set( OUTPUT      "${CMAKE_CURRENT_BINARY_DIR}/build/timestamp" )
    set( DEPS        "pyreclab" )
 
+   execute_process( COMMAND python -c "import distutils.util; print(distutils.util.get_platform())" OUTPUT_VARIABLE PY_PLATFORM )
    configure_file( ${SETUP_PY_IN} ${SETUP_PY} )
 
    add_custom_command( OUTPUT ${OUTPUT}
                        COMMAND ${CMAKE_COMMAND} -E copy "pypackage/__init__.py" "${PROJECT_BINARY_DIR}/pyreclab/"
-                       COMMAND ${PYTHON} ${SETUP_PY} bdist_egg
+                       COMMAND ${PYTHON} ${SETUP_PY} bdist_wheel "--plat-name" ${PY_PLATFORM}
                        COMMAND ${CMAKE_COMMAND} -E touch ${OUTPUT}
                        DEPENDS ${DEPS} )
 


### PR DESCRIPTION
This commit try to create a package more compatible with binary things.

I changed the way to create the python package, wheel is a useful way to package binaries things. And if you create a wheel package you could upload to https://pypi.org/ this way is more easy to install for the users.

Please, before to accept the pull request read a little about wheels, to use wheel you need install some packages. Maybe this a good article to start

http://lucumr.pocoo.org/2014/1/27/python-on-wheels/

BTW I made a ubuntu docker container to create the package without need install boost, etc.

https://hub.docker.com/r/juanpabloaj/pyreclab-docker-ubuntu/

If you prefer I can transfer the control of the repository of the container.

cc: @lalanne