### PR TITLE
Fixes installation error on Mac

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -39,6 +39,8 @@ add_compile_options( -Wall )
 
 find_package( PythonLibs "${CMAKE_PYTHON_VERSION}"
               REQUIRED )
+find_package( Boost REQUIRED )
+include_directories(${Boost_INCLUDE_DIRS})
 
 #
 # Library building


### PR DESCRIPTION
Hi, thanks for this great collection of recommendation algorithms! When installing on Mac, I get:

```txt
Scanning dependencies of target pyinterface_native_py
[  2%] Building CXX object temp/pyinterface_native_py/CMakeFiles/pyinterface_native_py.dir/PyMostPopular.cpp.o
In file included from /Users/andrew/forks/pyreclab/pyinterface/PyMostPopular.cpp:1:
In file included from /Users/andrew/forks/pyreclab/pyinterface/PyMostPopular.h:6:
In file included from /Users/andrew/forks/pyreclab/algorithms/AlgMostPopular.h:4:
In file included from /Users/andrew/forks/pyreclab/algorithms/RecSysAlgorithm.h:4:
In file included from /Users/andrew/forks/pyreclab/datahandlers/RatingMatrix.h:5:
In file included from /Users/andrew/forks/pyreclab/datahandlers/SparseMatrix.h:4:
/Users/andrew/forks/pyreclab/datahandlers/SparseRow.h:4:10: fatal error: 'boost/numeric/ublas/matrix_sparse.hpp' file not found
#include <boost/numeric/ublas/matrix_sparse.hpp>
         ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
1 error generated.
make[2]: *** [temp/pyinterface_native_py/CMakeFiles/pyinterface_native_py.dir/PyMostPopular.cpp.o] Error 1
make[1]: *** [temp/pyinterface_native_py/CMakeFiles/pyinterface_native_py.dir/all] Error 2
make: *** [all] Error 2
```

This PR fixes it.